### PR TITLE
「フォロー」「フォロー解除」

### DIFF
--- a/src/components/atoms/FollowButton.jsx
+++ b/src/components/atoms/FollowButton.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import styled from "styled-components";
+
+const StyledButton = styled.button`
+  background-color: #007bff;
+  color: white;
+  padding: 10px 20px;
+  border-radius: 5px;
+  border: none;
+  cursor: pointer;
+`;
+
+const FollowButton = ({ isFollowing, handleFollow }) => (
+  <StyledButton onClick={handleFollow}>
+    {isFollowing ? "フォロー中" : "フォロー"}
+  </StyledButton>
+);
+
+export default FollowButton;

--- a/src/components/atoms/FollowButton.jsx
+++ b/src/components/atoms/FollowButton.jsx
@@ -10,8 +10,9 @@ const StyledButton = styled.button`
   cursor: pointer;
 `;
 
-const FollowButton = ({ isFollowing, handleFollow }) => (
-  <StyledButton onClick={handleFollow}>
+// isFollowingがtrueの場合は「フォロー中」、falseの場合は「フォロー」を表示
+const FollowButton = ({ isFollowing, handleFollow, handleUnfollow }) => (
+  <StyledButton onClick={isFollowing ? handleUnfollow : handleFollow}>
     {isFollowing ? "フォロー中" : "フォロー"}
   </StyledButton>
 );

--- a/src/components/atoms/FollowButton.jsx
+++ b/src/components/atoms/FollowButton.jsx
@@ -11,8 +11,8 @@ const StyledButton = styled.button`
 `;
 
 // isFollowingがtrueの場合は「フォロー中」、falseの場合は「フォロー」を表示
-const FollowButton = ({ isFollowing, handleFollow, handleUnfollow }) => (
-  <StyledButton onClick={isFollowing ? handleUnfollow : handleFollow}>
+const FollowButton = ({ isFollowing, handleToggleFollow }) => (
+  <StyledButton onClick={handleToggleFollow}>
     {isFollowing ? "フォロー中" : "フォロー"}
   </StyledButton>
 );

--- a/src/components/organisms/UserProfile.jsx
+++ b/src/components/organisms/UserProfile.jsx
@@ -66,7 +66,8 @@ const UserProfile = () => {
       const followingResponse = await axios.get(
         `/follow/${userId}/is-following`
       );
-      setIsFollowing(followingResponse.data); // フォロー状態を設定
+      console.log("followingResponse", followingResponse);
+      setIsFollowing(followingResponse.data.isFollowing); // フォロー状態を設定
     };
 
     fetchUserProfile();
@@ -76,6 +77,12 @@ const UserProfile = () => {
   const handleFollow = async () => {
     await axios.post(`/follow/${userId}`);
     setIsFollowing(true);
+  };
+
+  // フォローを解除する
+  const handleUnfollow = async () => {
+    await axios.delete(`/unfollow/${userId}`);
+    setIsFollowing(false);
   };
 
   // ユーザープロフィール情報が取得できるまでローディング表示
@@ -103,6 +110,7 @@ const UserProfile = () => {
             <FollowButton
               isFollowing={isFollowing}
               handleFollow={handleFollow}
+              handleUnfollow={handleUnfollow}
             />
           </UpdateButtonContainer>
         )}

--- a/src/components/organisms/UserProfile.jsx
+++ b/src/components/organisms/UserProfile.jsx
@@ -10,6 +10,7 @@ import Username from "../atoms/Username";
 import Bio from "../atoms/Bio";
 import TabButtons from "../molecules/TabButtons";
 import UserCommentsList from "./UserCommentsList";
+import FollowButton from "../atoms/FollowButton";
 
 // スタイル定義
 const ProfileContainer = styled.div`
@@ -49,6 +50,8 @@ const UserProfile = () => {
   const loggedInUserId = localStorage.getItem("id");
   // ユーザープロフィール情報を取得
   const [userProfile, setUserProfile] = useState(null);
+  // フォロー状態を管理する状態変数
+  const [isFollowing, setIsFollowing] = useState(false);
   // タブの状態を管理する状態変数
   const [tab, setTab] = useState("posts");
 
@@ -61,6 +64,12 @@ const UserProfile = () => {
 
     fetchUserProfile();
   }, [userId]);
+
+  // フォローを行う
+  const handleFollow = async () => {
+    await axios.post(`/follow/${userId}`);
+    setIsFollowing(true);
+  };
 
   // ユーザープロフィール情報が取得できるまでローディング表示
   if (!userProfile) {
@@ -76,10 +85,18 @@ const UserProfile = () => {
           <Username text={userProfile.username} />
           <Bio text={userProfile.bio.String} />
         </div>
-        {/* ログインユーザーの場合表示する */}
-        {userId === loggedInUserId && (
+        {userId === loggedInUserId ? (
+          // ログインユーザーの場合に表示する
           <UpdateButtonContainer>
             <UpdateUserProfileModal />
+          </UpdateButtonContainer>
+        ) : (
+          // ログインユーザー以外の場合にフォローボタンを表示
+          <UpdateButtonContainer>
+            <FollowButton
+              isFollowing={isFollowing}
+              handleFollow={handleFollow}
+            />
           </UpdateButtonContainer>
         )}
       </UserInfoSection>

--- a/src/components/organisms/UserProfile.jsx
+++ b/src/components/organisms/UserProfile.jsx
@@ -45,6 +45,8 @@ const UpdateButtonContainer = styled.div`
 const UserProfile = () => {
   // ユーザーIDをURLパラメータから取得
   const { userId } = useParams();
+  // ログインユーザーのIDを取得
+  const loggedInUserId = localStorage.getItem("id");
   // ユーザープロフィール情報を取得
   const [userProfile, setUserProfile] = useState(null);
   // タブの状態を管理する状態変数
@@ -74,9 +76,12 @@ const UserProfile = () => {
           <Username text={userProfile.username} />
           <Bio text={userProfile.bio.String} />
         </div>
-        <UpdateButtonContainer>
-          <UpdateUserProfileModal />
-        </UpdateButtonContainer>
+        {/* ログインユーザーの場合表示する */}
+        {userId === loggedInUserId && (
+          <UpdateButtonContainer>
+            <UpdateUserProfileModal />
+          </UpdateButtonContainer>
+        )}
       </UserInfoSection>
       <TabBar>
         <TabButtons currentTab={tab} setTab={setTab} />

--- a/src/components/organisms/UserProfile.jsx
+++ b/src/components/organisms/UserProfile.jsx
@@ -73,16 +73,14 @@ const UserProfile = () => {
     fetchUserProfile();
   }, [userId]);
 
-  // フォローを行う
-  const handleFollow = async () => {
-    await axios.post(`/follow/${userId}`);
-    setIsFollowing(true);
-  };
-
-  // フォローを解除する
-  const handleUnfollow = async () => {
-    await axios.delete(`/unfollow/${userId}`);
-    setIsFollowing(false);
+  // フォロー/フォロー解除を切り替える
+  const handleToggleFollow = async () => {
+    if (isFollowing) {
+      await axios.delete(`/unfollow/${userId}`);
+    } else {
+      await axios.post(`/follow/${userId}`);
+    }
+    setIsFollowing((prevIsFollowing) => !prevIsFollowing);
   };
 
   // ユーザープロフィール情報が取得できるまでローディング表示
@@ -109,8 +107,7 @@ const UserProfile = () => {
           <UpdateButtonContainer>
             <FollowButton
               isFollowing={isFollowing}
-              handleFollow={handleFollow}
-              handleUnfollow={handleUnfollow}
+              handleToggleFollow={handleToggleFollow}
             />
           </UpdateButtonContainer>
         )}

--- a/src/components/organisms/UserProfile.jsx
+++ b/src/components/organisms/UserProfile.jsx
@@ -44,9 +44,9 @@ const UpdateButtonContainer = styled.div`
 `;
 
 const UserProfile = () => {
-  // ユーザーIDをURLパラメータから取得
+  // 「ツイートのユーザー」IDをパラメータから取得
   const { userId } = useParams();
-  // ログインユーザーのIDを取得
+  // 「ログインユーザー」のIDを取得
   const loggedInUserId = localStorage.getItem("id");
   // ユーザープロフィール情報を取得
   const [userProfile, setUserProfile] = useState(null);
@@ -58,8 +58,15 @@ const UserProfile = () => {
   // ユーザープロフィール情報を取得
   useEffect(() => {
     const fetchUserProfile = async () => {
+      // ツイートのユーザー情報を取得
       const response = await axios.get(`/user/${userId}`);
       setUserProfile(response.data); // ユーザープロフィール情報を設定
+
+      // ツイートのユーザーがログインユーザーをフォローしているか確認
+      const followingResponse = await axios.get(
+        `/follow/${userId}/is-following`
+      );
+      setIsFollowing(followingResponse.data); // フォロー状態を設定
     };
 
     fetchUserProfile();

--- a/src/components/pages/TweetsList.jsx
+++ b/src/components/pages/TweetsList.jsx
@@ -18,6 +18,15 @@ const TweetContainer = styled(Link)`
   } // マウスオーバー時の背景色
 `;
 
+const Username = styled(Link)`
+  color: blue;
+  text-decoration: none;
+  cursor: pointer;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
 const TweetImage = styled.img`
   width: 100%;
   max-height: 400px;
@@ -90,7 +99,7 @@ const TweetsList = () => {
       <h2>ツイート一覧</h2>
       {tweets.map((tweet) => (
         <TweetContainer to={`/tweets/${tweet.id}`} key={tweet.id}>
-          <strong>{tweet.user}</strong>
+          <Username to={`/user/${tweet.user_id}`}>{tweet.username}</Username>
           <p>{tweet.message}</p>
           {tweet.image_url.Valid && (
             <TweetImage src={tweet.image_url.String} alt="Tweet" />


### PR DESCRIPTION
- ツイート一覧画面からユーザー名をクリックするとプロフィール画面に遷移するようにする
ユーザー名を表示させ、クリックするとプロフィール画面に遷移できたことを確認しました。

<img width="1042" alt="スクリーンショット 2024-04-05 16 27 19" src="https://github.com/Syota622/twitter_react_frontend/assets/48635906/54ae7350-e3e8-497b-acfa-621f9f8331f5">

- プロフィール画面でフォローできるようにする
- フォロー後はフォローボタンをフォロー中に変更する
- プロフィール画面でフォロー解除できるようにする
- フォロー解除後はフォローにボタンを変更する
ボタンをクリックすると、`フォロー` `フォロー中`になることを確認しました。

<img width="649" alt="スクリーンショット 2024-04-05 16 28 36" src="https://github.com/Syota622/twitter_react_frontend/assets/48635906/7a105dbc-2ea2-425e-babe-3468271f2582">
<img width="712" alt="スクリーンショット 2024-04-05 16 29 13" src="https://github.com/Syota622/twitter_react_frontend/assets/48635906/8e81074b-531d-48d8-984e-9504277d2e42">
