### PR TITLE
ダイレクトメッセージ

### DIFF
--- a/src/components/atoms/SubmitButton.jsx
+++ b/src/components/atoms/SubmitButton.jsx
@@ -1,0 +1,7 @@
+import React from "react";
+
+const SubmitButton = ({ onClick, children }) => (
+  <button onClick={onClick}>{children}</button>
+);
+
+export default SubmitButton;

--- a/src/components/molecules/MessageForm.jsx
+++ b/src/components/molecules/MessageForm.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import styled from "styled-components";
+import InputField from "../atoms/InputField";
+import SubmitButton from "../atoms/SubmitButton";
+
+const StyledInputField = styled(InputField)`
+  margin-right: 10px; // 下側に10pxのマージンを追加
+`;
+
+const MessageForm = ({ newMessage, setNewMessage, handlePostMessage }) => (
+  <>
+    <StyledInputField
+      value={newMessage}
+      onChange={(e) => setNewMessage(e.target.value)}
+      placeholder="メッセージ"
+    />
+    <SubmitButton onClick={handlePostMessage}>投稿</SubmitButton>
+  </>
+);
+
+export default MessageForm;

--- a/src/components/organisms/CommentModal.jsx
+++ b/src/components/organisms/CommentModal.jsx
@@ -36,7 +36,7 @@ const CommentModal = ({ isOpen, tweetId, onClose, onCommentPosted }) => {
     formData.append("comment", comment);
 
     try {
-      await axios.post("/comment", formData, {
+      await axios.post("/comments", formData, {
         headers: {
           "Content-Type": "multipart/form-data",
         },

--- a/src/components/organisms/GroupDetail.jsx
+++ b/src/components/organisms/GroupDetail.jsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import axios from "../../utils/axios"; // カスタムインスタンスをインポート
+import styled from "styled-components";
+
+const GroupDetailContainer = styled.div`
+  padding: 20px;
+  background-color: #f5f8fa;
+`;
+
+const MessageItem = styled.div`
+  padding: 20px;
+  border-radius: 15px;
+  margin-bottom: 10px;
+  background-color: #fff;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+`;
+
+const GroupDetail = () => {
+  const { groupId } = useParams();
+  const [group, setGroup] = useState({ name: "", messages: [] });
+  const [newMessage, setNewMessage] = useState("");
+
+  useEffect(() => {
+    const fetchGroupMessages = async () => {
+      const response = await axios.get(`/group-messages/${groupId}`);
+      setGroup({ name: "Group Name", messages: response.data });
+    };
+
+    fetchGroupMessages();
+  }, [groupId]);
+
+  const handlePostMessage = async () => {
+    if (newMessage.trim() === "") {
+      return;
+    }
+
+    const userId = localStorage.getItem("id"); // ログインユーザーのIDをlocalStorageから取得
+
+    const response = await axios.post("/group-message", {
+      group_id: String(groupId), // group_idをstring型に変換
+      user_id: userId, // ログインユーザーのIDを使用
+      message: newMessage,
+    });
+
+    setGroup((prevGroup) => ({
+      ...prevGroup,
+      messages: [...prevGroup.messages, response.data],
+    }));
+
+    setNewMessage("");
+  };
+
+  if (!group) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <GroupDetailContainer>
+      <h2>{group.name}</h2>
+      {group.messages &&
+        group.messages.map((msg) => (
+          <MessageItem key={msg.id}>
+            <p>{msg.message}</p>
+          </MessageItem>
+        ))}
+      <input
+        type="text"
+        value={newMessage}
+        onChange={(e) => setNewMessage(e.target.value)}
+      />
+      <button onClick={handlePostMessage}>投稿</button>
+    </GroupDetailContainer>
+  );
+};
+
+export default GroupDetail;

--- a/src/components/organisms/GroupDetail.jsx
+++ b/src/components/organisms/GroupDetail.jsx
@@ -24,7 +24,7 @@ const GroupDetail = () => {
 
   useEffect(() => {
     const fetchGroupMessages = async () => {
-      const response = await axios.get(`/group-messages/${groupId}`);
+      const response = await axios.get(`/group/${groupId}/messages`);
       setGroup({
         name: response.data[0].group_id.Int32,
         messages: response.data ? response.data : [], // response.dataが存在しない場合は空の配列を設定
@@ -42,7 +42,7 @@ const GroupDetail = () => {
 
     const userId = localStorage.getItem("id"); // ログインユーザーのIDをlocalStorageから取得
 
-    const response = await axios.post("/group-message", {
+    const response = await axios.post(`/group/${groupId}/messages`, {
       group_id: groupId, // グループIDを使用
       user_id: userId, // ログインユーザーのIDを使用
       message: newMessage,

--- a/src/components/organisms/GroupDetail.jsx
+++ b/src/components/organisms/GroupDetail.jsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import axios from "../../utils/axios"; // カスタムインスタンスをインポート
 import styled from "styled-components";
-import InputField from "../atoms/InputField";
-import SubmitButton from "../atoms/SubmitButton";
+import MessageForm from "../molecules/MessageForm";
 
 const GroupDetailContainer = styled.div`
   padding: 20px;
@@ -26,7 +25,10 @@ const GroupDetail = () => {
   useEffect(() => {
     const fetchGroupMessages = async () => {
       const response = await axios.get(`/group-messages/${groupId}`);
-      setGroup({ name: "Group Name", messages: response.data });
+      setGroup({
+        name: "Group Name",
+        messages: response.data ? response.data : [], // response.dataが存在しない場合は空の配列を設定
+      });
     };
 
     fetchGroupMessages();
@@ -68,11 +70,11 @@ const GroupDetail = () => {
             <p>{msg.message}</p>
           </MessageItem>
         ))}
-      <InputField
-        value={newMessage}
-        onChange={(e) => setNewMessage(e.target.value)}
+      <MessageForm
+        newMessage={newMessage}
+        setNewMessage={setNewMessage}
+        handlePostMessage={handlePostMessage}
       />
-      <SubmitButton onClick={handlePostMessage}>投稿</SubmitButton>
     </GroupDetailContainer>
   );
 };

--- a/src/components/organisms/GroupDetail.jsx
+++ b/src/components/organisms/GroupDetail.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import axios from "../../utils/axios"; // カスタムインスタンスをインポート
 import styled from "styled-components";
+import InputField from "../atoms/InputField";
+import SubmitButton from "../atoms/SubmitButton";
 
 const GroupDetailContainer = styled.div`
   padding: 20px;
@@ -66,12 +68,11 @@ const GroupDetail = () => {
             <p>{msg.message}</p>
           </MessageItem>
         ))}
-      <input
-        type="text"
+      <InputField
         value={newMessage}
         onChange={(e) => setNewMessage(e.target.value)}
       />
-      <button onClick={handlePostMessage}>投稿</button>
+      <SubmitButton onClick={handlePostMessage}>投稿</SubmitButton>
     </GroupDetailContainer>
   );
 };

--- a/src/components/organisms/GroupDetail.jsx
+++ b/src/components/organisms/GroupDetail.jsx
@@ -31,6 +31,7 @@ const GroupDetail = () => {
   }, [groupId]);
 
   const handlePostMessage = async () => {
+    // メッセージが空の場合は何もしない
     if (newMessage.trim() === "") {
       return;
     }
@@ -38,11 +39,12 @@ const GroupDetail = () => {
     const userId = localStorage.getItem("id"); // ログインユーザーのIDをlocalStorageから取得
 
     const response = await axios.post("/group-message", {
-      group_id: String(groupId), // group_idをstring型に変換
+      group_id: groupId, // グループIDを使用
       user_id: userId, // ログインユーザーのIDを使用
       message: newMessage,
     });
 
+    // メッセージを追加
     setGroup((prevGroup) => ({
       ...prevGroup,
       messages: [...prevGroup.messages, response.data],

--- a/src/components/organisms/GroupDetail.jsx
+++ b/src/components/organisms/GroupDetail.jsx
@@ -26,7 +26,7 @@ const GroupDetail = () => {
     const fetchGroupMessages = async () => {
       const response = await axios.get(`/group-messages/${groupId}`);
       setGroup({
-        name: "Group Name",
+        name: response.data[0].group_id.Int32,
         messages: response.data ? response.data : [], // response.dataが存在しない場合は空の配列を設定
       });
     };

--- a/src/components/organisms/GroupList.jsx
+++ b/src/components/organisms/GroupList.jsx
@@ -35,6 +35,7 @@ const GroupList = () => {
 
   return (
     <GroupListContainer>
+      {/* グループは、curlやpostmanから新規作成する */}
       <h1>グループ一覧</h1>
       {groups.map((group) => (
         <GroupItem key={group.id}>

--- a/src/components/organisms/GroupList.jsx
+++ b/src/components/organisms/GroupList.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import axios from "../../utils/axios"; // カスタムインスタンスをインポート
+import styled from "styled-components";
+
+const GroupListContainer = styled.div`
+  padding: 20px;
+  background-color: #f5f8fa;
+`;
+
+const GroupItem = styled.div`
+  padding: 20px;
+  border-radius: 15px;
+  margin-bottom: 10px;
+  background-color: #fff;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+`;
+
+const StyledLink = styled(Link)`
+  text-decoration: none;
+  color: #333;
+`;
+
+const GroupList = () => {
+  const [groups, setGroups] = useState([]);
+
+  useEffect(() => {
+    const fetchGroups = async () => {
+      const response = await axios.get("/groups");
+      setGroups(response.data);
+    };
+
+    fetchGroups();
+  }, []);
+
+  return (
+    <GroupListContainer>
+      <h1>グループ一覧</h1>
+      {groups.map((group) => (
+        <GroupItem key={group.id}>
+          <StyledLink to={`/group/${group.id}`}>{group.name}</StyledLink>
+        </GroupItem>
+      ))}
+    </GroupListContainer>
+  );
+};
+
+export default GroupList;

--- a/src/components/organisms/TweetForm.jsx
+++ b/src/components/organisms/TweetForm.jsx
@@ -25,7 +25,7 @@ const TweetForm = () => {
 
     // 画像アップロードとツイートの投稿を処理するAPIエンドポイントにリクエストを送信
     try {
-      await axios.post("/tweet", formData);
+      await axios.post("/tweets", formData);
       alert("ツイートが投稿されました！");
     } catch (error) {
       console.error("ツイートの投稿に失敗しました。", error);

--- a/src/components/templates/Content.jsx
+++ b/src/components/templates/Content.jsx
@@ -5,6 +5,8 @@ import TweetsList from "../pages/TweetsList";
 import TweetDetail from "../pages/TweetDetail";
 import UserProfile from "../organisms/UserProfile";
 import Notifications from "../organisms/Notifications";
+import GroupList from "../organisms/GroupList";
+import GroupDetail from "../organisms/GroupDetail";
 
 const ContentContainer = styled.div`
   flex: 2;
@@ -23,6 +25,10 @@ const Content = () => {
         <Route path="/user/:userId" element={<UserProfile />} />
         {/* 通知 */}
         <Route path="/notifications" element={<Notifications />} />
+        {/* グループ一覧 */}
+        <Route path="/groups" element={<GroupList />} />
+        {/* グループ詳細 */}
+        <Route path="/group/:groupId" element={<GroupDetail />} />
       </Routes>
     </ContentContainer>
   );

--- a/src/components/templates/Sidebar.jsx
+++ b/src/components/templates/Sidebar.jsx
@@ -48,7 +48,7 @@ const Sidebar = () => {
   return (
     <SidebarContainer>
       <StyledLink to="/">ホーム</StyledLink>
-      <StyledLink>メッセージ</StyledLink>
+      <StyledLink to="/groups">メッセージ</StyledLink>
       <StyledLink to="/notifications">通知</StyledLink>
       <StyledLink>設定</StyledLink>
       <StyledLink>ログアウト</StyledLink>


### PR DESCRIPTION
- サイドバーからメッセージ画面に遷移できるようにする
- 遷移後はグループ一覧画面に遷移する

サイドバーのメッセージから、グループ一覧画面に遷移したことを確認
<img width="1125" alt="スクリーンショット 2024-04-13 11 27 31" src="https://github.com/Syota622/twitter_react_frontend/assets/48635906/8aecf4b1-d832-462f-8e6c-d5f02c970ca3">

- 任意のグループを選択するとグループ詳細画面が表示され、メッセージの表示、投稿ができるようにする

メッセージの表示と投稿ができることを確認
<img width="1147" alt="スクリーンショット 2024-04-13 11 27 42" src="https://github.com/Syota622/twitter_react_frontend/assets/48635906/3f52fffc-69e4-4f36-a1f4-169b66ce328f">
